### PR TITLE
Bump bun

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,17 +4,17 @@ on:
     push:
     pull_request:
         branches:
-        - master
+        - main
 
 jobs:
   build:
     name: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v1
+      - uses: actions/checkout@v4.1.1
+      - uses: oven-sh/setup-bun@v1.1.1
         with:
-          bun-version: 1.0.18
+          bun-version: 1.0.19
       - name: install dependencies
         run: bun install
       - name: lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     name: build
     runs-on: ubuntu-latest
+    timeout-minutes: 1
     steps:
       - uses: actions/checkout@v4.1.1
       - uses: oven-sh/setup-bun@v1.1.1


### PR DESCRIPTION
Set a 1 min timeout on the github action. This way no free minutes go wasted if something out of the ordinary happens.

Bump to bun 1.0.19.

Explicitly use the latest checkout and bun action extensions. 